### PR TITLE
Fix commonjs support for native lib file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,9 +154,14 @@ pnpm-lock.yaml
 
 # build
 src/native.js
+src/native.cjs
 src/native.d.ts
+src/native.d.cts
 src/browser.js
 src/*wasi*js
 
 # Apple
 .DS_Store
+
+# IDEs
+.idea

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
 	],
 	"scripts": {
 		"build:napi:release": "napi build --platform --release --esm --output-dir src --js native.js --dts native.d.ts",
-		"build:release": "pnpm build:napi:release && pnpm build:ts && pnpm build:copy",
+		"build:napi:release:cjs": "napi build --platform --release --output-dir src --js native.cjs --dts native.d.cts",
+		"build:release": "pnpm build:napi:release && pnpm build:napi:release:cjs && pnpm build:ts && pnpm build:copy",
 		"build:napi:debug": "napi build --platform --esm --output-dir src --js native.js --dts native.d.ts",
-		"build": "pnpm build:napi:debug && pnpm build:ts && pnpm build:copy",
+		"build:napi:debug:cjs": "napi build --platform --output-dir src --js native.cjs --dts native.d.cts",
+		"build": "pnpm build:napi:debug && pnpm build:napi:debug:cjs && pnpm build:ts && pnpm build:copy",
 		"build:linux": "napi build --platform --release --target x86_64-unknown-linux-gnu",
 		"build:ts": "tsup",
 		"build:copy": "cp src/qrbit.*.node dist/ && cp src/native.* dist/",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,11 +8,24 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   outDir: 'dist',
-  external: ['./native.js'],
+  external: ['./native.js', './native.cjs'],
   noExternal: [],
   outExtension({ format }) {
     return {
       js: format === 'cjs' ? '.cjs' : '.js'
+    }
+  },
+  onSuccess: async () => {
+    // After successful build, replace ./native.js with ./native.cjs in the CommonJS output
+    const fs = await import('fs')
+    const path = await import('path')
+
+    const cjsFile = path.join('dist', 'qrbit.cjs')
+
+    if (fs.existsSync(cjsFile)) {
+      let content = fs.readFileSync(cjsFile, 'utf8')
+      content = content.replace(/require\(["']\.\/native\.js["']\)/g, 'require("./native.cjs")')
+      fs.writeFileSync(cjsFile, content, 'utf8')
     }
   }
 })


### PR DESCRIPTION
**Follow the [Contributing](./CONTRIBUTING.md) guidelines and check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - Fixed module compatibility issue where CommonJS builds couldn't properly import native bindings
  - Now generates both ESM (native.js) and CommonJS (native.cjs) versions of the native module
  - Package now fully supports both import and require syntax

 #### Problem

  Previously, the package exported both ESM and CommonJS versions (qrbit.js and qrbit.cjs), but the
   native bindings were only generated as ESM (native.js). This caused the CommonJS build to fail
  when trying to require() an ES module, breaking compatibility for CommonJS environments.