### PR TITLE
root - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Setup pnpm (version is read from the packageManager field in package.json)
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # Setup Node
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -50,6 +50,6 @@ jobs:
         run: pnpm test:ci
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Setup pnpm (version is read from the packageManager field in package.json)
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # Setup Node - Skip for Alpine (already in container)
       - name: Use Node.js
         if: matrix.build_env != 'alpine'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -77,7 +77,7 @@ jobs:
         run: pnpm test:ci
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: qa-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.target }}
           path: dist/*.node
@@ -89,15 +89,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Setup pnpm (version is read from the packageManager field in package.json)
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # Setup Node
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -109,7 +109,7 @@ jobs:
         run: pnpm build:release
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Setup pnpm (version is read from the packageManager field in package.json)
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # Setup Node
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -57,15 +57,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Setup pnpm (version is read from the packageManager field in package.json)
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # Setup Node
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm


### PR DESCRIPTION
## Summary
Upgrade all GitHub Actions to their latest major versions. Pin style (`@vX` major tag) is preserved.

## Versions
- `actions/checkout` `v4` → `v6`
- `actions/setup-node` `v4` → `v6`
- `pnpm/action-setup` `v4` → `v6`
- `codecov/codecov-action` `v5` → `v6`
- `actions/upload-artifact` `v4` → `v7`
- `actions/download-artifact` `v4` → `v8`
- `dtolnay/rust-toolchain@stable` — unchanged (branch ref, no version)

## Tests
- [x] All workflow YAML still parses

## Breaking notes
All bumps cross a major version, but no workflow logic changes were required:
- `pnpm/action-setup`/`setup-node`: existing pnpm-before-node ordering and `cache: pnpm` are still valid; pnpm version is read from the `packageManager` field.
- `codecov-action` v6: already passes `token`, satisfying the CLI-based requirement introduced in v5.
- `upload-artifact` v7 / `download-artifact` v8: both use the v4+ artifact backend and interoperate; matrix artifact names are unique (no collisions) and the download step uses a recursive `find` for `*.node`, so the existing flow holds. Note: `release.yml` only runs on `release: published`, so it isn't exercised by PR CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_019t1dVHsdiDm3oXcGkH8PbN)_