### PR TITLE
root - chore: upgrade hookified (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
 	},
 	"dependencies": {
 		"cacheable": "^2.3.5",
-		"hookified": "^2.2.0",
+		"hookified": "^3.0.0",
 		"qrcode": "^1.5.4"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.3.5
         version: 2.3.5
       hookified:
-        specifier: ^2.2.0
-        version: 2.2.0
+        specifier: ^3.0.0
+        version: 3.0.0
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1644,6 +1644,10 @@ packages:
 
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  hookified@3.0.0:
+    resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
+    engines: {node: '>=22.18.0'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -3289,6 +3293,8 @@ snapshots:
   hookified@1.15.1: {}
 
   hookified@2.2.0: {}
+
+  hookified@3.0.0: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Summary
Upgrade the `hookified` runtime dependency across a major version.

## Versions
- `hookified` `2.2.0` → `3.0.0`

## Tests
- [x] `pnpm build` passes (napi native module + tsdown)
- [x] `pnpm test` passes (biome lint + 184 vitest tests, 100% statements/lines)

## Breaking notes
v3 introduces **no public API changes** — `QrBit extends Hookified`, the `HookifiedOptions` type, and `this.emit(...)` all work unchanged (build + full test suite pass with no source edits). The only breaking aspect is the runtime floor: v3 **drops Node 20 and requires Node >=22.18.0**. The project's supported Node versions (CI matrix 22/24/26) already satisfy this, so no further changes are needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_019t1dVHsdiDm3oXcGkH8PbN)_