### PR TITLE
root - chore: upgrade napi-rs dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,9 +288,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctor"
-version = "0.11.1"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
+checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 
 [[package]]
 name = "data-url"
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.8.6"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
 dependencies = [
  "bitflags",
  "ctor",
@@ -913,15 +913,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.5"
+version = "3.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
+checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
 dependencies = [
  "convert_case",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ svg = "0.18"
 base64 = "0.22"
 resvg = "0.47"
 tiny-skia = "0.12"
-napi = "3.8.6"
-napi-derive = "3.5.5"
+napi = "3.9.0"
+napi-derive = "3.5.6"
 quircs = "0.10"
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
Upgrade the napi-rs ecosystem crates to their latest versions.

## Versions
- `napi` 3.8.6 → 3.9.0
- `napi-derive` 3.5.5 → 3.5.6
- `napi-build` 2.3.1 → 2.3.2 (lockfile only — requirement is `"2"`)

Transitive: `ctor` 0.11.1 → 1.0.6 (pulled in by the new `napi-derive`).

## Checks
- [x] `pnpm build` passes (recompiles the Rust native module via napi)
- [x] `pnpm test:ci` passes — 184/184 tests, 100% line coverage


---
_Generated by [Claude Code](https://claude.ai/code/session_01AuRFLFCwQeEYbqaZ9pHaEX)_