### PR TITLE
release: v3.0.0 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "qrbit",
-	"version": "2.1.0",
+	"version": "3.0.0",
 	"description": "A fast QR code generator with logo embedding support",
 	"type": "module",
 	"packageManager": "pnpm@11.4.0",


### PR DESCRIPTION
## Release summary
Dependency and tooling maintenance release; raises the minimum Node.js version to 22.18.0 (drops Node 20).

## qrbit@3.0.0 — 2026-05-28

Dependency and tooling maintenance release; raises the minimum Node.js version to 22.18.0.

### ⚠ BREAKING CHANGES
- Minimum Node.js is now **>=22.18.0** — Node 20 is no longer supported (via `hookified` v3) (67de454, #104)
  Migration: upgrade your runtime to Node.js 22.18.0 or newer before updating qrbit. No source/API changes are required — `QrBit extends Hookified`, `HookifiedOptions`, and `emit(...)` are unchanged.

### Internal
- upgrade napi-rs dependencies: `napi` 3.8.6→3.9.0, `napi-derive` 3.5.5→3.5.6 (30cd46e, #105)
- upgrade `hookified` 2.2.0→3.0.0 (67de454, #104)
- upgrade `cacheable` 2.3.4→2.3.5 (e3d29b5, #103)
- upgrade GitHub Actions to latest majors (checkout v6, setup-node v6, pnpm/action-setup v6, codecov v6, upload-artifact v7, download-artifact v8) (94aafb2, #102)
- upgrade TypeScript build tooling: `tsx` 4.21.0→4.22.3, `tsdown` 0.21.10→0.22.0 (fe267b0, #101)
- upgrade code-quality deps: `@biomejs/biome` 2.4.13→2.4.15, `vitest`/`@vitest/coverage-v8` 4.1.5→4.1.7, `tinybench` 6.0.1→6.0.2 (a1b6859, #100)
- migrate to pnpm 11 with corepack; update CI Node matrix to 22, 24, 26 (c2ae753, 27d38d1, #99)

### Contributors
- @jaredwray (8)

### Full List of Changes
- Migrate to pnpm 11 with corepack by @jaredwray in #99
- root - chore: upgrade code quality dependencies by @jaredwray in #100
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #101
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #102
- root - chore: upgrade cacheable by @jaredwray in #103
- root - chore: upgrade hookified (breaking) by @jaredwray in #104
- root - chore: upgrade napi-rs dependencies by @jaredwray in #105

**Full diff:** https://github.com/jaredwray/qrbit/compare/v2.1.0...v3.0.0

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile unchanged)
- [x] `pnpm build` succeeds (Rust native module + tsdown)
- [x] `pnpm test:ci` passes locally — 184/184 tests, 100% lines
- [x] No uncommitted changes outside the version bump

## Post-merge
Merge then create a GitHub Release at tag `v3.0.0` — the `release.yml` workflow (triggered on `release: published`) builds the platform artifacts and publishes to npm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM2rcJAwLBh92T6KJxDD95)_